### PR TITLE
Correct configure message for Debian/Ubuntu package

### DIFF
--- a/configure
+++ b/configure
@@ -6,7 +6,7 @@
 
 # Library settings
 PKG_CONFIG_NAME="libopenmpt portaudio-2.0 portaudiocpp"
-PKG_DEB_NAME="libopenmpt-dev portaudio-dev"
+PKG_DEB_NAME="libopenmpt-dev portaudio19-dev"
 PKG_RPM_NAME="libopenmpt-devel portaudio-devel"
 PKG_BREW_NAME="libopenmpt"
 PKG_LIBS="-llibportaudio -llibportaudiocpp -llibopenmpt"


### PR DESCRIPTION
This is actually correct in DESCRIPTION, but I had to re-discover it the hard way when building the r2u binary.  It would be nice if the message could be corrected too.